### PR TITLE
Adding request tagging support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
+  - "0.12"
   - "0.11"
   - "0.10"

--- a/src/http/HTTPService.coffee
+++ b/src/http/HTTPService.coffee
@@ -6,7 +6,10 @@ module.exports = (superagent, Promise, _, SpurErrors, FormData)->
   Request::plugin = (plugin)->
     (@_plugins ?= []).push(plugin)
     @
+
   Request::named = (@name)-> @
+
+  Request::tags = (@tags = {})-> @
 
   Request::getDefaultName = ->
     return @url.match(/\/\/(.+)\/?/)[1].replace(/\./g, "_")
@@ -69,5 +72,3 @@ module.exports = (superagent, Promise, _, SpurErrors, FormData)->
   superagent.setGlobalPlugins = (@globalPlugins)->
 
   superagent
-
-

--- a/src/http/HTTPService.coffee
+++ b/src/http/HTTPService.coffee
@@ -17,6 +17,7 @@ module.exports = (superagent, Promise, _, SpurErrors, FormData)->
   Request::promise = ->
     self = this
     self.name ?= @getDefaultName()
+    self.tags ?= {}
     @_plugins = (@_plugins or []).concat(superagent.globalPlugins)
     @_pluginInstances = _.compact _.map @_plugins, (p)->
       p.start(self)

--- a/test/unit/http/HTTPServiceSpec.coffee
+++ b/test/unit/http/HTTPServiceSpec.coffee
@@ -39,9 +39,11 @@ describe "HTTPService", ->
     @HTTPService
       .get("http://someurl")
       .named("LoginService")
+      .tags({endpoint: "EndpointName", tag2: "Some tag value"})
       .plugin(HTTPLogging)
       .promise().then (res)->
         expect(res.request.name).to.equal "LoginService"
+        expect(res.request.tags).to.deep.equal {endpoint: "EndpointName", tag2: "Some tag value"}
         expect(res.request.duration).to.equal 33
         expect(logs).to.deep.equal [ 'LoginService', 'http://someurl' ]
         done()


### PR DESCRIPTION
There is a time where requests need to be tagged with specific data so that it can be used in plugins, reports and other stuff.