### PR TITLE
Reverting the coverall support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,3 @@ node_js:
   - "0.12"
   - "4.2"
   - "5"
-after_success:
-  - 'cat ./coverage/lcov.info | ./node_modules/.bin/coveralls'

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A [Node.js](http://nodejs.org/) library of common modules used to create common applications.
 
 [![NPM version](https://badge.fury.io/js/spur-common.png)](http://badge.fury.io/js/spur-common)
-[![Build Status](https://travis-ci.org/opentable/spur-common.png?branch=master)](https://travis-ci.org/opentable/spur-common) [![Dependencies](https://david-dm.org/opentable/spur-common.svg)](https://david-dm.org/opentable/spur-common) [![Coverage Status](https://coveralls.io/repos/github/opentable/spur-common/badge.svg?branch=master)](https://coveralls.io/github/opentable/spur-common?branch=master)
+[![Build Status](https://travis-ci.org/opentable/spur-common.png?branch=master)](https://travis-ci.org/opentable/spur-common) [![Dependencies](https://david-dm.org/opentable/spur-common.svg)](https://david-dm.org/opentable/spur-common)
 
 # About the Spur Framework
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "license": "MIT",
   "scripts": {
-    "test": "mocha --opts ./test/mocha.opts ./test/ && istanbul report text-summary lcov"
+    "test": "mocha --opts ./test/mocha.opts ./test/"
   },
   "bugs": {
     "url": "https://github.com/opentable/spur-common/issues"
@@ -55,9 +55,6 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
-    "coffee-coverage": "^1.0.1",
-    "coveralls": "^2.11.6",
-    "istanbul": "^0.4.2",
     "mocha": "^2.4.5",
     "nock": "^7.0.2",
     "sinon": "^1.17.3"

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,5 +1,4 @@
 --require ./test/globals.js
 --compilers coffee:coffee-script/register
---require coffee-coverage/register-istanbul
 --recursive
 --timeout 10000


### PR DESCRIPTION
Until I find a way that will cover dependency injected code.

cc @ssetem Have you tried this before and had any success? Coverall and Istanbul work with angular that has a similar approach, but for spur-ioc we may need to build something custom.