### PR TITLE
Separating integration and unit tests into their own runs to help coverage reporting

### DIFF
--- a/.istanbul.yml
+++ b/.istanbul.yml
@@ -1,0 +1,2 @@
+instrumentation:
+    root: src

--- a/package.json
+++ b/package.json
@@ -22,10 +22,13 @@
     "dev": "babel --watch src -d lib",
     "lint": "eslint .",
     "pretest": "npm run lint",
-    "test": "babel-node --debug node_modules/mocha/bin/_mocha ./test/",
+    "test-unit": "babel-node --debug node_modules/mocha/bin/_mocha ./test/unit/",
+    "test-integration": "babel-node --debug node_modules/mocha/bin/_mocha ./test/integration/",
+    "test": "npm run unit-test && npm run test-integration",
     "test-watch": "babel-node --debug node_modules/mocha/bin/_mocha --watch ./test/",
-    "precoveralls": "npm run build-and-test",
-    "coveralls": "babel-node node_modules/isparta/bin/isparta cover --report text ./node_modules/mocha/bin/_mocha --report lcovonly ./test/ && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage",
+    "coverage": "babel-node node_modules/isparta/bin/isparta cover --report text ./node_modules/mocha/bin/_mocha --report lcovonly ./test/unit/",
+    "precoveralls": "npm run build && npm run test-integration",
+    "coveralls": "npm run coverage && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage",
     "build-and-test": "npm run build && npm test"
   },
   "bugs": {

--- a/test/integration/main_ModuleIntegration_Spec.js
+++ b/test/integration/main_ModuleIntegration_Spec.js
@@ -1,68 +1,66 @@
-// Disabling integration tests for a short time due to test coverage issues:
-// https://github.com/douglasduteil/isparta/issues/24.
-// Unable to exclude /lib from the coverage report which fails tests.
+import spur from 'spur-ioc';
+// NEED to use require vs import to test module export for backward compatability
+const mainModule = require('../../');
 
-// import spur from 'spur-ioc';
-// // NEED to use require vs import to test module export for backward compatability
-// const mainModule = require('../../');
-//
-// describe('Main Module Integration Tests', () => {
-//   beforeEach(function () {
-//     this.console = console;
-//     this.JSON = JSON;
-//
-//     this.ioc = spur.create('test-spur-common');
-//     this.ioc.merge(mainModule());
-//   });
-//
-//   describe('base dependencies', () => {
-//     it('base module dependencies are injectable', function () {
-//       this.ioc.inject((_, Promise, fs, path, SpurErrors, winston, moment, superagent, FormData, consoleColors) => {
-//         expect(_).to.exist;
-//         expect(Promise).to.exist;
-//         expect(fs).to.exist;
-//         expect(path).to.exist;
-//         expect(SpurErrors).to.exist;
-//         expect(winston).to.exist;
-//         expect(moment).to.exist;
-//         expect(superagent).to.exist;
-//         expect(FormData).to.exist;
-//         expect(consoleColors).to.exist;
-//       });
-//     });
-//
-//     it('should inject `console` and match type', function () {
-//       this.ioc.inject((console) => {
-//         expect(console).to.equal(this.console);
-//       });
-//     });
-//
-//     it('should inject `JSON` and match type', function () {
-//       this.ioc.inject((JSON) => {
-//         expect(JSON).to.equal(this.JSON);
-//       });
-//     });
-//
-//     it('should inject `nodeProcess` and match type', function () {
-//       this.ioc.inject((nodeProcess) => {
-//         expect(nodeProcess).to.equal(process);
-//       });
-//     });
-//   });
-//
-//   describe('versions', () => {
-//     it('should be using lodash 3.x', function () {
-//       this.ioc.inject((_) => {
-//         const result = Number(_.VERSION.split('.')[0]);
-//         expect(result).to.equal(3);
-//       });
-//     });
-//
-//     it('should be using moment 2.x', function () {
-//       this.ioc.inject((moment) => {
-//         const result = Number(moment.version.split('.')[0]);
-//         expect(result).to.equal(2);
-//       });
-//     });
-//   });
-// });
+describe('Integration', () => {
+  describe('Main Module Integration Tests', () => {
+    beforeEach(function () {
+      this.console = console;
+      this.JSON = JSON;
+
+      this.ioc = spur.create('test-spur-common');
+      this.ioc.merge(mainModule());
+    });
+
+    describe('base dependencies', () => {
+      it('base module dependencies are injectable', function () {
+        this.ioc.inject((_, Promise, fs, path, SpurErrors, winston, moment, superagent, FormData, consoleColors) => {
+          expect(_).to.exist;
+          expect(Promise).to.exist;
+          expect(fs).to.exist;
+          expect(path).to.exist;
+          expect(SpurErrors).to.exist;
+          expect(winston).to.exist;
+          expect(moment).to.exist;
+          expect(superagent).to.exist;
+          expect(FormData).to.exist;
+          expect(consoleColors).to.exist;
+        });
+      });
+
+      it('should inject `console` and match type', function () {
+        this.ioc.inject((console) => {
+          expect(console).to.equal(this.console);
+        });
+      });
+
+      it('should inject `JSON` and match type', function () {
+        this.ioc.inject((JSON) => {
+          expect(JSON).to.equal(this.JSON);
+        });
+      });
+
+      it('should inject `nodeProcess` and match type', function () {
+        this.ioc.inject((nodeProcess) => {
+          expect(nodeProcess).to.equal(process);
+        });
+      });
+    });
+
+    describe('versions', () => {
+      it('should be using lodash 3.x', function () {
+        this.ioc.inject((_) => {
+          const result = Number(_.VERSION.split('.')[0]);
+          expect(result).to.equal(3);
+        });
+      });
+
+      it('should be using moment 2.x', function () {
+        this.ioc.inject((moment) => {
+          const result = Number(moment.version.split('.')[0]);
+          expect(result).to.equal(2);
+        });
+      });
+    });
+  });
+});

--- a/test/integration/registerConfig_ModuleIntegration_Spec.js
+++ b/test/integration/registerConfig_ModuleIntegration_Spec.js
@@ -1,46 +1,44 @@
-// Disabling integration tests for a short time due to test coverage issues:
-// https://github.com/douglasduteil/isparta/issues/24.
-// Unable to exclude /lib from the coverage report which fails tests.
+/* eslint-disable no-console */
 
-// /* eslint-disable no-console */
-//
-// import path from 'path';
-// // NEED to use require vs import to test module export for backward compatability
-// const registerConfig = require('../../registerConfig');
-//
-// describe('registerConfig Module Integration Tests', () => {
-//   it('default configName', () => {
-//     const ioc = injector();
-//     const configPath = path.join(__dirname, '../fixtures/config');
-//
-//     registerConfig(ioc, configPath);
-//
-//     ioc.inject((config, configLoader) => {
-//       expect(config).to.deep.equal({ a: 'a', c: 'c' });
-//       expect(configLoader.configName).to.equal('test');
-//     });
-//   });
-//
-//   it('specified configName', () => {
-//     const ioc = injector();
-//     const configPath = path.join(__dirname, '../fixtures/config');
-//
-//     registerConfig(ioc, configPath, 'alphaConfig');
-//
-//     ioc.inject((alphaConfig, alphaConfigLoader) => {
-//       expect(alphaConfig).to.deep.equal({ a: 'a', c: 'c' });
-//       expect(alphaConfigLoader.configName).to.equal('test');
-//     });
-//   });
-//
-//   it('errors', () => {
-//     const ioc = injector();
-//     const configPath = path.join(__dirname, '../fixtures/config2');
-//
-//     expect(() => {
-//       console.log('===== EXPECTED ERROR BELOW =====');
-//       registerConfig(ioc, configPath, 'alphaConfig');
-//     })
-//     .to.throw();
-//   });
-// });
+import path from 'path';
+// NEED to use require vs import to test module export for backward compatability
+const registerConfig = require('../../registerConfig');
+
+describe('Integration', () => {
+  describe('registerConfig Module Integration Tests', () => {
+    it('default configName', () => {
+      const ioc = injector();
+      const configPath = path.join(__dirname, '../fixtures/config');
+
+      registerConfig(ioc, configPath);
+
+      ioc.inject((config, configLoader) => {
+        expect(config).to.deep.equal({ a: 'a', c: 'c' });
+        expect(configLoader.configName).to.equal('test');
+      });
+    });
+
+    it('specified configName', () => {
+      const ioc = injector();
+      const configPath = path.join(__dirname, '../fixtures/config');
+
+      registerConfig(ioc, configPath, 'alphaConfig');
+
+      ioc.inject((alphaConfig, alphaConfigLoader) => {
+        expect(alphaConfig).to.deep.equal({ a: 'a', c: 'c' });
+        expect(alphaConfigLoader.configName).to.equal('test');
+      });
+    });
+
+    it('errors', () => {
+      const ioc = injector();
+      const configPath = path.join(__dirname, '../fixtures/config2');
+
+      expect(() => {
+        console.log('===== EXPECTED ERROR BELOW =====');
+        registerConfig(ioc, configPath, 'alphaConfig');
+      })
+      .to.throw();
+    });
+  });
+});


### PR DESCRIPTION
Breaking out the integration and unit tests commands to run at different stages so that integration tests that use generated code from `lib/` are not in the coverage report.

Also addressing a common error with babel being able to parse mocha responses properly: https://github.com/douglasduteil/isparta/issues/47#issuecomment-121014224