### PR TITLE
Use latest lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,16 +37,15 @@
   },
   "dependencies": {
     "bluebird": "^2.9.3",
-    "superagent": "^3.0.0",
     "colors": "1.1.0",
     "form-data": "^0.2.0",
     "joi": "^5.1.0",
-    "lodash": "^4.0.0",
+    "lodash": "^4.17.4",
     "moment-timezone": "^0.3.0",
     "spur-config": "^1.0.0",
     "spur-errors": "^0.2.1",
     "spur-ioc": "^0.2.1",
-    "superagent": "^1.7.2",
+    "superagent": "^3.3.1",
     "winston": "^0.8.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -36,17 +36,18 @@
     "url": "git://github.com/opentable/spur-common.git"
   },
   "dependencies": {
-    "spur-ioc": "^0.2.1",
-    "spur-errors": "^0.2.1",
-    "spur-config": "^1.0.0",
-    "lodash": "^3.0.0",
     "bluebird": "^2.9.3",
-    "winston": "^0.8.3",
     "superagent": "^3.0.0",
-    "moment-timezone": "^0.3.0",
+    "colors": "1.1.0",
     "form-data": "^0.2.0",
     "joi": "^5.1.0",
-    "colors": "1.1.0"
+    "lodash": "^4.0.0",
+    "moment-timezone": "^0.3.0",
+    "spur-config": "^1.0.0",
+    "spur-errors": "^0.2.1",
+    "spur-ioc": "^0.2.1",
+    "superagent": "^1.7.2",
+    "winston": "^0.8.3"
   },
   "devDependencies": {
     "babel-cli": "^6.5.1",

--- a/registerConfig.js
+++ b/registerConfig.js
@@ -1,2 +1,2 @@
 /* This file is here to support backward compatability with previous verions */
-module.exports = require('./lib/iocConfigRegistration');
+module.exports = require('./lib/iocConfigRegistration'); // eslint-disable-line

--- a/registerConfig.js
+++ b/registerConfig.js
@@ -1,2 +1,2 @@
 /* This file is here to support backward compatability with previous verions */
-module.exports = require('./lib/iocConfigRegistration'); // eslint-disable-line
+module.exports = require('./src/iocConfigRegistration');

--- a/registerConfig.js
+++ b/registerConfig.js
@@ -1,2 +1,2 @@
 /* This file is here to support backward compatability with previous verions */
-module.exports = require('./src/iocConfigRegistration');
+module.exports = require('./lib/iocConfigRegistration'); //eslint-disable-line

--- a/src/core/BaseDelegate.js
+++ b/src/core/BaseDelegate.js
@@ -50,11 +50,12 @@ module.exports = function (_, console, consoleColors) {
 
     getColoredLabel(methodName) {
       const label = `${this.constructor.name}#${methodName}: `;
+      const checkMethodType = (item) => item === methodName;
       let color = 'cyan';
 
-      if (_.contains(['fatal', 'error'], methodName)) {
+      if (_.some(['fatal', 'error'], checkMethodType)) {
         color = 'red';
-      } else if (_.contains(['warn'], methodName)) {
+      } else if (_.some(['warn'], checkMethodType)) {
         color = 'yellow';
       }
 

--- a/src/http/HTTPService.js
+++ b/src/http/HTTPService.js
@@ -36,7 +36,6 @@ module.exports = function (superagent, Promise, _, FormData, HTTPResponseProcess
     if (self.tags == null) { self.tags = {}; }
 
     this._plugins = (this._plugins || []).concat(superagent.globalPlugins);
-
     this._pluginInstances = _.compact(_.map(this._plugins, (p) => p.start(self)));
 
     return new Promise((resolve, reject) => {
@@ -52,7 +51,7 @@ module.exports = function (superagent, Promise, _, FormData, HTTPResponseProcess
           resolve(res);
         }
 
-        return _.invoke(self._pluginInstances, 'end');
+        return _.invokeMap(self._pluginInstances, 'end');
       });
     });
   };
@@ -100,7 +99,7 @@ module.exports = function (superagent, Promise, _, FormData, HTTPResponseProcess
 
   superagent.setGlobalPlugins = function (plugins) {
     if (_.isArray(plugins)) {
-      superagent.globalPlugins = _.unique(_.union(superagent.globalPlugins, plugins));
+      superagent.globalPlugins = _.uniq(_.union(superagent.globalPlugins, plugins));
       return superagent.globalPlugins;
     }
 
@@ -110,7 +109,8 @@ module.exports = function (superagent, Promise, _, FormData, HTTPResponseProcess
   superagent.getGlobalPlugins = () => superagent.globalPlugins;
 
   superagent.addGlobalPlugin = function (plugin) {
-    if (!_.contains(superagent.globalPlugins, plugin)) {
+    const checkPluginExists = (pluginOpt) => pluginOpt === plugin;
+    if (!_.some(superagent.globalPlugins, checkPluginExists)) {
       superagent.globalPlugins.push(plugin);
     }
 

--- a/test/integration/main_ModuleIntegration_Spec.js
+++ b/test/integration/main_ModuleIntegration_Spec.js
@@ -48,10 +48,10 @@ describe('Integration', () => {
     });
 
     describe('versions', () => {
-      it('should be using lodash 3.x', function () {
+      it('should be using lodash 4.x', function () {
         this.ioc.inject((_) => {
           const result = Number(_.VERSION.split('.')[0]);
-          expect(result).to.equal(3);
+          expect(result).to.equal(4);
         });
       });
 

--- a/test/unit/core/joiSpec.js
+++ b/test/unit/core/joiSpec.js
@@ -45,7 +45,7 @@ describe('joi', () => {
 
   it('should reject invalid data through async', function (done) {
     this.joi.validateAsync(this.invalidData, this.schema)
-    .error((error) => {
+    .catch((error) => {
       expect(error.message).to.deep.equal('username is required');
       done();
     });

--- a/test/unit/fixtures/FixtureUtilSpec.js
+++ b/test/unit/fixtures/FixtureUtilSpec.js
@@ -54,7 +54,7 @@ describe('FixtureUtil', () => {
     this.FixtureUtil.setFixturesPath(this.expectedFixturesPath);
     const missingPath = this.path.join(this.expectedFixturesPath, 'missingFileName.json');
     this.FixtureUtil.readAndProcessFile('missingFileName')
-    .error((reason) => {
+    .catch((reason) => {
       expect(reason.message).to.equal(`${missingPath} not found`);
       done();
     });


### PR DESCRIPTION
Part of: _Update deps and distro major version of spur-common_

Update HTTPService and BaseDelegate to use the latest lodash methods. Some methods were deprecated.

Link for list of breaking changes:
https://github.com/lodash/lodash/wiki/Changelog#compatibility-warnings