### PR TITLE
update moment-timezone

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "form-data": "^0.2.0",
     "joi": "^5.1.0",
     "lodash": "^4.17.4",
-    "moment-timezone": "^0.3.0",
+    "moment-timezone": "^0.5.11",
     "spur-config": "^1.0.0",
     "spur-errors": "^0.2.1",
     "spur-ioc": "^0.2.1",


### PR DESCRIPTION
Part of: _Update deps and distro major version of spur-common_

Link to the changelog: https://github.com/moment/moment-timezone/blob/master/changelog.md
Doesn't appear to have any breaking changes.