### PR TITLE
Optimizing the lodash usage and no longer exposing as an injectable dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,6 @@ List of external dependencies used and exposed by spur-common. They can be found
 
 | Name              | Original Module Name                                             |
 | :----             | :----                                                            |
-| **-**             | [lodash](https://www.npmjs.org/package/lodash)                   |
 | **Promise**       | [bluebird](https://www.npmjs.org/package/bluebird)               |
 | **winston**       | [winston](https://www.npmjs.org/package/winston)                 |
 | **moment**        | [moment-timezone](https://www.npmjs.org/package/moment-timezone) |

--- a/package.json
+++ b/package.json
@@ -56,9 +56,9 @@
     "lodash.union": "4.6.0",
     "lodash.uniq": "4.5.0",
     "moment-timezone": "^0.5.11",
-    "spur-config": "^1.0.0",
+    "spur-config": ">=2.0.0-rc.1",
     "spur-errors": "^0.2.1",
-    "spur-ioc": "^0.2.1",
+    "spur-ioc": ">=1.0.0-rc.1",
     "superagent": "^3.3.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,17 @@
     "colors": "1.1.0",
     "form-data": "^2.1.2",
     "joi": "^10.1.0",
-    "lodash": "^4.17.4",
+    "lodash.assignin": "4.2.0",
+    "lodash.bindall": "4.4.0",
+    "lodash.compact": "3.0.1",
+    "lodash.foreach": "4.5.0",
+    "lodash.invokemap": "4.6.0",
+    "lodash.isempty": "4.4.0",
+    "lodash.isfunction": "3.0.8",
+    "lodash.map": "4.6.0",
+    "lodash.some": "4.6.0",
+    "lodash.union": "4.6.0",
+    "lodash.uniq": "4.5.0",
     "moment-timezone": "^0.5.11",
     "spur-config": "^1.0.0",
     "spur-errors": "^0.2.1",
@@ -55,8 +65,10 @@
     "chai": "^4.1.1",
     "eslint": "^4.5.0",
     "eslint-plugin-node": "^5.1.1",
+    "lodash.every": "4.6.0",
+    "lodash.last": "3.0.0",
     "mocha": "^3.5.0",
-    "sinon": "^3.2.1",
-    "nock": "^8.0.0"
+    "nock": "^8.0.0",
+    "sinon": "^3.2.1"
   }
 }

--- a/src/core/BaseDelegate.js
+++ b/src/core/BaseDelegate.js
@@ -1,4 +1,8 @@
-module.exports = function (_, console, consoleColors) {
+const _forEach = require('lodash.foreach');
+const _isFunction = require('lodash.isfunction');
+const _some = require('lodash.some');
+
+module.exports = function (console, consoleColors) {
   class BaseDelegate {
 
     constructor() {
@@ -22,10 +26,10 @@ module.exports = function (_, console, consoleColors) {
     }
 
     callDelegate(methodName, args) {
-      _.each(this.delegates, (delegate) => {
-        if (_.isFunction(delegate[methodName])) {
+      _forEach(this.delegates, (delegate) => {
+        if (_isFunction(delegate[methodName])) {
           delegate[methodName].apply(delegate, args);
-        } else if (_.isFunction(delegate)) {
+        } else if (_isFunction(delegate)) {
           delegate.call(this, methodName, args);
         }
       });
@@ -51,9 +55,9 @@ module.exports = function (_, console, consoleColors) {
       const checkMethodType = (item) => item === methodName;
       let color = 'cyan';
 
-      if (_.some(['fatal', 'error'], checkMethodType)) {
+      if (_some(['fatal', 'error'], checkMethodType)) {
         color = 'red';
-      } else if (_.some(['warn'], checkMethodType)) {
+      } else if (_some(['warn'], checkMethodType)) {
         color = 'yellow';
       }
 

--- a/src/fixtures/FixtureCache.js
+++ b/src/fixtures/FixtureCache.js
@@ -1,10 +1,12 @@
-module.exports = function (Promise, _) {
+const _bindAll = require('lodash.bindall');
+
+module.exports = function (Promise) {
   class FixtureCache {
 
     constructor() {
       this.cache = {};
 
-      _.bindAll(this, ['set', 'get', 'getOrPromise', 'setAsync']);
+      _bindAll(this, ['set', 'get', 'getOrPromise', 'setAsync']);
     }
 
     set(key, value) {

--- a/src/fixtures/FixtureUtil.js
+++ b/src/fixtures/FixtureUtil.js
@@ -1,8 +1,10 @@
-module.exports = function (path, Promise, fsPromise, FixtureCache, Logger, _) {
+const _bindAll = require('lodash.bindall');
+
+module.exports = function (path, Promise, fsPromise, FixtureCache, Logger) {
   class FixtureUtil {
 
     constructor(fixturesPath) {
-      _.bindAll(this, ['get', 'readAndProcessFile', 'startFileRead']);
+      _bindAll(this, ['get', 'readAndProcessFile', 'startFileRead']);
       this.fixturesPath = fixturesPath;
       this.cache = FixtureCache;
     }

--- a/src/http/HTTPResponseProcessing.js
+++ b/src/http/HTTPResponseProcessing.js
@@ -1,4 +1,6 @@
-module.exports = function (SpurErrors, _) {
+const _isEmpty = require('lodash.isempty');
+
+module.exports = function (SpurErrors) {
   class HTTPResponseProcessing {
 
     constructor(method, url, response, error) {
@@ -60,7 +62,7 @@ module.exports = function (SpurErrors, _) {
 
     _setErrorData(res) {
       if (this.error) {
-        const errorResponse = _.isEmpty(res.body) ? res.text : res.body;
+        const errorResponse = _isEmpty(res.body) ? res.text : res.body;
         this.error.setData(errorResponse);
       }
     }

--- a/src/http/HTTPService.js
+++ b/src/http/HTTPService.js
@@ -1,4 +1,12 @@
-module.exports = function (superagent, Promise, _, FormData, HTTPResponseProcessing) {
+const _forEeach = require('lodash.foreach');
+const _compact = require('lodash.compact');
+const _map = require('lodash.map');
+const _invokeMap = require('lodash.invokemap');
+const _uniq = require('lodash.uniq');
+const _union = require('lodash.union');
+const _some = require('lodash.some');
+
+module.exports = function (superagent, Promise, FormData, HTTPResponseProcessing) {
   const Request = superagent.Request;
 
   superagent.globalPlugins = [];
@@ -34,7 +42,7 @@ module.exports = function (superagent, Promise, _, FormData, HTTPResponseProcess
     if (self.tags == null) { self.tags = {}; }
 
     this._plugins = (this._plugins || []).concat(superagent.globalPlugins);
-    this._pluginInstances = _.compact(_.map(this._plugins, (p) => p.start(self)));
+    this._pluginInstances = _compact(_map(this._plugins, (p) => p.start(self)));
 
     return new Promise((resolve, reject) => {
       Request.prototype.end.call(self, (err, res) => {
@@ -49,7 +57,7 @@ module.exports = function (superagent, Promise, _, FormData, HTTPResponseProcess
           resolve(res);
         }
 
-        return _.invokeMap(self._pluginInstances, 'end');
+        return _invokeMap(self._pluginInstances, 'end');
       });
     });
   };
@@ -96,8 +104,8 @@ module.exports = function (superagent, Promise, _, FormData, HTTPResponseProcess
   };
 
   superagent.setGlobalPlugins = function (plugins) {
-    if (_.isArray(plugins)) {
-      superagent.globalPlugins = _.uniq(_.union(superagent.globalPlugins, plugins));
+    if (Array.isArray(plugins)) {
+      superagent.globalPlugins = _uniq(_union(superagent.globalPlugins, plugins));
       return superagent.globalPlugins;
     }
 
@@ -108,7 +116,7 @@ module.exports = function (superagent, Promise, _, FormData, HTTPResponseProcess
 
   superagent.addGlobalPlugin = function (plugin) {
     const checkPluginExists = (pluginOpt) => pluginOpt === plugin;
-    if (!_.some(superagent.globalPlugins, checkPluginExists)) {
+    if (!_some(superagent.globalPlugins, checkPluginExists)) {
       superagent.globalPlugins.push(plugin);
     }
 

--- a/src/injector.js
+++ b/src/injector.js
@@ -1,7 +1,5 @@
 const spur = require('spur-ioc');
 
-// Resolvable dependencies
-const _ = require('lodash');
 const Promise = require('bluebird');
 const fs = require('fs');
 const path = require('path');
@@ -15,7 +13,6 @@ function dependencyRegistration() {
   const ioc = spur.create('spur-common');
 
   ioc.registerDependencies({
-    _,
     Promise,
     fs,
     path,

--- a/src/utils/Utils.js
+++ b/src/utils/Utils.js
@@ -1,13 +1,16 @@
-module.exports = function (_, Promise, fsPromise, JSON) {
+const _bindAll = require('lodash.bindall');
+const _assignIn = require('lodash.assignin');
+
+module.exports = function (Promise, fsPromise, JSON) {
   class Utils {
 
     constructor() {
-      _.bindAll(this, ['readFile', 'readJsonFile']);
+      _bindAll(this, ['readFile', 'readJsonFile']);
     }
 
     prop(prop) { return (ob) => ob[prop]; }
 
-    extendWith(ob1) { return (ob2) => _.extend(ob2, ob1); }
+    extendWith(ob1) { return (ob2) => _assignIn(ob2, ob1); }
 
     capitalize(str) {
       if (!str) {

--- a/test/globals.js
+++ b/test/globals.js
@@ -5,7 +5,6 @@ global.sinon = require('sinon');
 global.chai = require('chai');
 global.expect = global.chai.expect;
 global.nock = require('nock');
-global._ = require('lodash');
 
 global.srcDir = path.resolve(__dirname, '../src');
 global.injector = require(path.join(__dirname, 'fixtures', 'injector.js'));

--- a/test/integration/main_ModuleIntegration_Spec.js
+++ b/test/integration/main_ModuleIntegration_Spec.js
@@ -13,8 +13,7 @@ describe('Integration', () => {
 
     describe('base dependencies', () => {
       it('base module dependencies are injectable', function () {
-        this.ioc.inject(function (_, Promise, fs, path, SpurErrors, moment, superagent, FormData, consoleColors) {
-          expect(_).to.exist;
+        this.ioc.inject(function (Promise, fs, path, SpurErrors, moment, superagent, FormData, consoleColors) {
           expect(Promise).to.exist;
           expect(fs).to.exist;
           expect(path).to.exist;
@@ -46,13 +45,6 @@ describe('Integration', () => {
     });
 
     describe('versions', () => {
-      it('should be using lodash 4.x', function () {
-        this.ioc.inject(function (_) {
-          const result = Number(_.VERSION.split('.')[0]);
-          expect(result).to.equal(4);
-        });
-      });
-
       it('should be using moment 2.x', function () {
         this.ioc.inject(function (moment) {
           const result = Number(moment.version.split('.')[0]);

--- a/test/unit/http/HTTPServiceSpec.js
+++ b/test/unit/http/HTTPServiceSpec.js
@@ -1,3 +1,5 @@
+const _every = require('lodash.every');
+
 describe('HTTPService', () => {
   const base = this;
 
@@ -14,7 +16,7 @@ describe('HTTPService', () => {
       base.Timer.mockDuration(base.mockDuration);
 
       base.containsText = (text, arr) => {
-        return _.every(arr, (expectedText) => {
+        return _every(arr, (expectedText) => {
           return text.indexOf(expectedText) > -1;
         });
       };

--- a/test/unit/logging/ConsoleLoggerSpec.js
+++ b/test/unit/logging/ConsoleLoggerSpec.js
@@ -1,3 +1,5 @@
+const _last = require('lodash.last');
+
 describe('ConsoleLogger', () => {
   const base = this;
 
@@ -8,13 +10,12 @@ describe('ConsoleLogger', () => {
 
     injector()
       .addDependency('console', base.MockLogger, true)
-      .inject(function (ConsoleLogger, console, _) {
+      .inject(function (ConsoleLogger, console) {
         base.ConsoleLogger = ConsoleLogger;
         base.console = console;
-        base._ = _;
 
         base.getResult = () => {
-          return base._.last(base.console.log.getCalls()).args;
+          return _last(base.console.log.getCalls()).args;
         };
       });
   });

--- a/test/unit/logging/LoggerSpec.js
+++ b/test/unit/logging/LoggerSpec.js
@@ -1,3 +1,5 @@
+const _last = require('lodash.last');
+
 describe('Logger', () => {
   const base = this;
 
@@ -8,13 +10,12 @@ describe('Logger', () => {
 
     injector()
       .addDependency('console', base.MockLogger, true)
-      .inject(function (Logger, console, _) {
+      .inject(function (Logger, console) {
         base.Logger = Logger;
         base.console = console;
-        base._ = _;
 
         base.getResult = () => {
-          return base._.last(base.console.log.getCalls()).args;
+          return _last(base.console.log.getCalls()).args;
         };
       });
   });


### PR DESCRIPTION
Provides two optimizations:

1. Allows consumers the ability to use what ever version of lodash they choose without waiting for spur-common to be updated.

2. Lightens the production packages by a nice chunk. About 2-3mb