### PR TITLE
refactor(api): Switches from deprecated `new Buffer()` constructor to `Buffer.from()`

### DIFF
--- a/src/http/HTTPService.js
+++ b/src/http/HTTPService.js
@@ -90,7 +90,7 @@ module.exports = function (superagent, Promise, FormData, HTTPResponseProcessing
       });
 
       res.on('end', () => {
-        fn(null, new Buffer(res.data, 'binary'));
+        fn(null, Buffer.from(res.data, 'binary'));
       });
     }).buffer(true);
   };

--- a/test/unit/http/HTTPServiceSpec.js
+++ b/test/unit/http/HTTPServiceSpec.js
@@ -134,7 +134,7 @@ describe('HTTPService', () => {
     .reply(200);
 
     base.HTTPService.post('http://someurl/')
-    .appendFile('file', new Buffer('hello world'), {
+    .appendFile('file', Buffer.from('hello world'), {
       filename: 'hello.json',
       contentType: 'application/json'
     })


### PR DESCRIPTION
Gets rid of the warnings at build time and, in some cases, runtime.