### PR TITLE
Added default header userAgent to request

### DIFF
--- a/src/http/HTTPService.js
+++ b/src/http/HTTPService.js
@@ -6,8 +6,36 @@ const _uniq = require('lodash.uniq');
 const _union = require('lodash.union');
 const _some = require('lodash.some');
 
+const pkg = require('../../package.json');
+
+const overrideActions = [
+  'get',
+  'post',
+  'del',
+  'delete',
+  'put',
+  'patch'
+];
+
+function overrideDefaultMethods(superagent) {
+  const backUpMethods = {};
+  const userAgent = `node-spur-common/${pkg.version}`;
+
+  overrideActions.forEach((actionName) => {
+    // Caching original functions 
+    backUpMethods[actionName] = superagent[actionName];
+
+    // Overriding the actions with custom actions, which will add default headers
+    superagent[actionName] = (url, data, fn) => {
+      return backUpMethods[actionName](url, data, fn).set('User-Agent', userAgent);
+    };
+  });
+}
+
 module.exports = function (superagent, Promise, FormData, HTTPResponseProcessing) {
   const Request = superagent.Request;
+
+  overrideDefaultMethods(superagent);
 
   superagent.globalPlugins = [];
 

--- a/test/unit/http/HTTPServiceSpec.js
+++ b/test/unit/http/HTTPServiceSpec.js
@@ -1,4 +1,8 @@
+const pkg = require('../../../package.json');
+
 describe('HTTPService', function () {
+
+  const userAgent = `node-spur-common/${pkg.version}`;
 
   beforeEach(() => {
     nock.disableNetConnect();
@@ -47,12 +51,17 @@ describe('HTTPService', function () {
 
     this.HTTPService
       .get('http://someurl')
+      .set('My-Custom-Header','My Custom Header Value')
       .named('LoginService')
       .tagged({ endpoint: 'EndpointName', tag2: 'Some tag value' })
       .plugin(HTTPLogging)
       .promise()
       .then((res) => {
         expect(res.request.name).to.equal('LoginService');
+        expect(res.request.header).to.deep.equal({
+          'User-Agent': userAgent,
+          'My-Custom-Header': 'My Custom Header Value'
+        });
         expect(res.request.tags).to.deep.equal({ endpoint: 'EndpointName', tag2: 'Some tag value' });
         expect(res.request.duration).to.equal(this.mockDuration);
         expect(logs).to.deep.equal(['LoginService', 'http://someurl']);


### PR DESCRIPTION
### Description
The super agent  removed default header `User-Agent: 'node-superagent/{version}'`  as part of 5.1.  This may impact consumers of HTTPService may face issues. So we are re-introducing it back. 