### PR TITLE
chore(timeout-errors): [RO-22835] Update spur-common to handle timeout errors to return 504

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,15 +1,15 @@
 {
   "env": {
-    "es2022": true,
+    "es6": true,
     "node": true
   },
   "plugins": ["node"],
   "parserOptions": {
-    "ecmaVersion": 13
+    "ecmaVersion": 6
   },
   "rules": {
     "node/no-unsupported-features": [2, {
-        "version": 9
+        "version": 6
       }
     ],
     "arrow-parens": ["error", "always"],

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,15 +1,15 @@
 {
   "env": {
-    "es6": true,
+    "es2022": true,
     "node": true
   },
   "plugins": ["node"],
   "parserOptions": {
-    "ecmaVersion": 6
+    "ecmaVersion": 13
   },
   "rules": {
     "node/no-unsupported-features": [2, {
-        "version": 6
+        "version": 9
       }
     ],
     "arrow-parens": ["error", "always"],

--- a/src/http/HTTPResponseProcessing.js
+++ b/src/http/HTTPResponseProcessing.js
@@ -26,24 +26,13 @@ module.exports = function (SpurErrors) {
     }
 
     _processError() {
-      const { error, method, url } = this.input;
-      const { code, errno, message, status } = error;
+      const err = this.input.error;
 
-      if (!status) {
-        const errorMessage = `HTTP Error: ${method} ${url} ${message}: {code: '${code}', errno: '${errno}'}`;
-
-        switch (errno) {
-          case 'ETIMEDOUT':
-          case 'ETIME':
-            this.error = SpurErrors.GatewayTimeoutError.create(errorMessage, error);
-            break;
-
-          default:
-            this.error = SpurErrors.InternalServerError.create(errorMessage, error);
-            break;
-        }
+      if (!err.status) {
+        const errorMessage = `HTTP Error: ${this.input.method} ${this.input.url} ${err.message}`;
+        this.error = SpurErrors.InternalServerError.create(errorMessage, err);
       } else {
-        this._setErrorByStatusCode(status);
+        this._setErrorByStatusCode(err.status);
       }
     }
 

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,7 +1,7 @@
 {
   "extends": "../.eslintrc",
   "env": {
-    "es2022": true,
+    "es6": true,
     "mocha": true,
     "node": true,
     "jasmine": true

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,7 +1,7 @@
 {
   "extends": "../.eslintrc",
   "env": {
-    "es6": true,
+    "es2022": true,
     "mocha": true,
     "node": true,
     "jasmine": true

--- a/test/unit/http/HTTPServiceSpec.js
+++ b/test/unit/http/HTTPServiceSpec.js
@@ -90,37 +90,6 @@ describe('HTTPService', function () {
       });
   });
 
-  it('timeout error', (done) => {
-    const httpServiceConnectionTimeout = 1;
-    nock('http://someurl')
-      .get('/')
-      .delay(httpServiceConnectionTimeout + 1)
-      .reply(200, 'FOUND');
-
-    const logs = [];
-
-    class HTTPLogging extends this.HTTPPlugin {
-      start() {}
-      end() {
-        const { response, ...rest } = this.request.error.internalError;
-        logs.push(this.request.name, this.request.url, { ...rest });
-      }
-    }
-
-    this.HTTPService
-      .get('http://someurl')
-      .timeout(httpServiceConnectionTimeout)
-      .named('LoginService')
-      .plugin(HTTPLogging)
-      .promise()
-      .catch((e) => {
-        expect(e.statusCode).to.equal(504);
-        expect(e.message).to.equal(`HTTP Error: GET http://someurl Timeout of ${httpServiceConnectionTimeout}ms exceeded: {code: 'ECONNABORTED', errno: 'ETIME'}`);
-        expect(logs).to.deep.equal(['LoginService', 'http://someurl', { timeout: httpServiceConnectionTimeout, code: 'ECONNABORTED', errno: 'ETIME' }]);
-        done();
-      });
-  });
-
   it('unknown http error', (done) => {
     nock('http://someurl')
       .get('/')

--- a/test/unit/http/HTTPServiceSpec.js
+++ b/test/unit/http/HTTPServiceSpec.js
@@ -90,6 +90,37 @@ describe('HTTPService', function () {
       });
   });
 
+  it('timeout error', (done) => {
+    const httpServiceConnectionTimeout = 1;
+    nock('http://someurl')
+      .get('/')
+      .delay(httpServiceConnectionTimeout + 1)
+      .reply(200, 'FOUND');
+
+    const logs = [];
+
+    class HTTPLogging extends this.HTTPPlugin {
+      start() {}
+      end() {
+        const { response, ...rest } = this.request.error.internalError;
+        logs.push(this.request.name, this.request.url, { ...rest });
+      }
+    }
+
+    this.HTTPService
+      .get('http://someurl')
+      .timeout(httpServiceConnectionTimeout)
+      .named('LoginService')
+      .plugin(HTTPLogging)
+      .promise()
+      .catch((e) => {
+        expect(e.statusCode).to.equal(504);
+        expect(e.message).to.equal(`HTTP Error: GET http://someurl Timeout of ${httpServiceConnectionTimeout}ms exceeded: {code: 'ECONNABORTED', errno: 'ETIME'}`);
+        expect(logs).to.deep.equal(['LoginService', 'http://someurl', { timeout: httpServiceConnectionTimeout, code: 'ECONNABORTED', errno: 'ETIME' }]);
+        done();
+      });
+  });
+
   it('unknown http error', (done) => {
     nock('http://someurl')
       .get('/')


### PR DESCRIPTION
## Ticket
https://opentable.atlassian.net/browse/RO-22842

## Summary
This PR will add logic to inspect superagent's timeout errors and return a 504 HTTP error for both connection and response timeouts

## Testing
Added unit test