### PR TITLE
chore(colors): [RO-26515] BREAKING: Removes color dependency. Removes publishing of consoleColors

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,6 @@ List of external dependencies used and exposed by spur-common. They can be found
 | **Promise**       | [bluebird](https://www.npmjs.org/package/bluebird)               |
 | **superagent**    | [superagent](https://www.npmjs.org/package/superagent)           |
 | **FormData**      | [form-data](https://www.npmjs.org/package/form-data)             |
-| **consoleColors** | [colors](https://www.npmjs.org/package/colors)                   |
 | **SpurErrors**    | [spur-errors](https://www.npmjs.org/package/spur-errors)         |
 
 ### Local dependecies

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "bluebird": "3.7.2",
-        "colors": "1.4.0",
         "form-data": "4.0.0",
         "lodash.compact": "3.0.1",
         "lodash.invokemap": "4.6.0",
@@ -1776,14 +1775,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/colors": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-      "engines": {
-        "node": ">=0.1.90"
-      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   },
   "dependencies": {
     "bluebird": "3.7.2",
-    "colors": "1.4.0",
     "form-data": "4.0.0",
     "lodash.compact": "3.0.1",
     "lodash.invokemap": "4.6.0",

--- a/src/core/BaseDelegate.js
+++ b/src/core/BaseDelegate.js
@@ -1,4 +1,4 @@
-module.exports = function (console, consoleColors) {
+module.exports = function (console) {
   class BaseDelegate {
 
     constructor() {
@@ -41,24 +41,14 @@ module.exports = function (console, consoleColors) {
     }
 
     consoleDelegate(methodName, args) {
-      const prefix = this.getColoredLabel(methodName);
+      const prefix = this.getLabel(methodName);
 
       // eslint-disable-next-line no-console
       return console.log.apply(console, [prefix].concat(args));
     }
 
-    getColoredLabel(methodName) {
-      const label = `${this.constructor.name}#${methodName}: `;
-      const checkMethodType = (item) => item === methodName;
-      let color = 'cyan';
-
-      if (['fatal', 'error'].some(checkMethodType)) {
-        color = 'red';
-      } else if (['warn'].some(checkMethodType)) {
-        color = 'yellow';
-      }
-
-      return consoleColors[color](label);
+    getLabel(methodName) {
+      return `${this.constructor.name}#${methodName}: `;
     }
 
     useRecorder() {

--- a/src/injector.js
+++ b/src/injector.js
@@ -6,7 +6,6 @@ const path = require('path');
 const SpurErrors = require('spur-errors');
 const superagent = require('superagent');
 const FormData = require('form-data');
-const consoleColors = require('colors/safe');
 
 function dependencyRegistration() {
   const ioc = spur.create('spur-common');
@@ -18,7 +17,6 @@ function dependencyRegistration() {
     SpurErrors,
     superagent,
     FormData,
-    consoleColors,
     console,
     nodeProcess: process,
     JSON

--- a/test/integration/main_ModuleIntegration.spec.js
+++ b/test/integration/main_ModuleIntegration.spec.js
@@ -16,14 +16,13 @@ describe('Integration', function () {
     describe('base dependencies', () => {
 
       it('base module dependencies are injectable', () => {
-        this.ioc.inject((Promise, fs, path, SpurErrors, superagent, FormData, consoleColors) => {
+        this.ioc.inject((Promise, fs, path, SpurErrors, superagent, FormData) => {
           expect(Promise).toBeDefined();
           expect(fs).toBeDefined();
           expect(path).toBeDefined();
           expect(SpurErrors).toBeDefined();
           expect(superagent).toBeDefined();
           expect(FormData).toBeDefined();
-          expect(consoleColors).toBeDefined();
         });
       });
 

--- a/test/unit/core/BaseDelegate.spec.js
+++ b/test/unit/core/BaseDelegate.spec.js
@@ -31,8 +31,8 @@ describe('BaseDelegate', function () {
     delegate.debug('hello');
 
     expect(this.logs).toEqual([
-      ['\u001b[36mSomeDelegate#log: \u001b[39m', 'hi'],
-      ['\u001b[36mSomeDelegate#debug: \u001b[39m', 'hello']
+      ['SomeDelegate#log: ', 'hi'],
+      ['SomeDelegate#debug: ', 'hello']
     ]);
 
     delegate.useRecorder();
@@ -64,9 +64,9 @@ describe('BaseDelegate', function () {
     delegate.log('foo');
 
     expect(this.logs).toEqual([
-      ['\u001b[36mSomeDelegate#log: \u001b[39m', 'foo'],
-      ['\u001b[36mSomeDelegate#log: \u001b[39m', 'foo'],
-      ['\u001b[36mSomeDelegate#log: \u001b[39m', 'foo']
+      ['SomeDelegate#log: ', 'foo'],
+      ['SomeDelegate#log: ', 'foo'],
+      ['SomeDelegate#log: ', 'foo']
     ]);
   });
 });

--- a/test/unit/logging/ConsoleLogger.spec.js
+++ b/test/unit/logging/ConsoleLogger.spec.js
@@ -16,36 +16,36 @@ describe('ConsoleLogger', function () {
 
   it('should fatal()', () => {
     this.ConsoleLogger.fatal('testing fatal');
-    expect(logSpy.mock.lastCall).toEqual(['\u001b[31mConsoleLogger#fatal: \u001b[39m', 'testing fatal']);
+    expect(logSpy.mock.lastCall).toEqual(['ConsoleLogger#fatal: ', 'testing fatal']);
   });
 
   it('should error()', () => {
     this.ConsoleLogger.error('testing error');
-    expect(logSpy.mock.lastCall).toEqual(['\u001b[31mConsoleLogger#error: \u001b[39m', 'testing error']);
+    expect(logSpy.mock.lastCall).toEqual(['ConsoleLogger#error: ', 'testing error']);
   });
 
   it('should warn()', () => {
     this.ConsoleLogger.warn('testing warn');
-    expect(logSpy.mock.lastCall).toEqual(['\u001b[33mConsoleLogger#warn: \u001b[39m', 'testing warn']);
+    expect(logSpy.mock.lastCall).toEqual(['ConsoleLogger#warn: ', 'testing warn']);
   });
 
   it('should info()', () => {
     this.ConsoleLogger.info('testing info');
-    expect(logSpy.mock.lastCall).toEqual(['\u001b[36mConsoleLogger#info: \u001b[39m', 'testing info']);
+    expect(logSpy.mock.lastCall).toEqual(['ConsoleLogger#info: ', 'testing info']);
   });
 
   it('should log()', () => {
     this.ConsoleLogger.log('testing log');
-    expect(logSpy.mock.lastCall).toEqual(['\u001b[36mConsoleLogger#log: \u001b[39m', 'testing log']);
+    expect(logSpy.mock.lastCall).toEqual(['ConsoleLogger#log: ', 'testing log']);
   });
 
   it('should debug()', () => {
     this.ConsoleLogger.debug('testing debug');
-    expect(logSpy.mock.lastCall).toEqual(['\u001b[36mConsoleLogger#debug: \u001b[39m', 'testing debug']);
+    expect(logSpy.mock.lastCall).toEqual(['ConsoleLogger#debug: ', 'testing debug']);
   });
 
   it('should verbose()', () => {
     this.ConsoleLogger.verbose('testing verbose');
-    expect(logSpy.mock.lastCall).toEqual(['\u001b[36mConsoleLogger#verbose: \u001b[39m', 'testing verbose']);
+    expect(logSpy.mock.lastCall).toEqual(['ConsoleLogger#verbose: ', 'testing verbose']);
   });
 });

--- a/test/unit/logging/Logger.spec.js
+++ b/test/unit/logging/Logger.spec.js
@@ -16,36 +16,36 @@ describe('Logger', () => {
 
   it('should fatal()', () => {
     this.Logger.fatal('testing fatal');
-    expect(logSpy.mock.lastCall).toEqual(['\u001b[31mLogger#fatal: \u001b[39m', 'testing fatal']);
+    expect(logSpy.mock.lastCall).toEqual(['Logger#fatal: ', 'testing fatal']);
   });
 
   it('should error()', () => {
     this.Logger.error('testing error');
-    expect(logSpy.mock.lastCall).toEqual(['\u001b[31mLogger#error: \u001b[39m', 'testing error']);
+    expect(logSpy.mock.lastCall).toEqual(['Logger#error: ', 'testing error']);
   });
 
   it('should warn()', () => {
     this.Logger.warn('testing warn');
-    expect(logSpy.mock.lastCall).toEqual(['\u001b[33mLogger#warn: \u001b[39m', 'testing warn']);
+    expect(logSpy.mock.lastCall).toEqual(['Logger#warn: ', 'testing warn']);
   });
 
   it('should info()', () => {
     this.Logger.info('testing info');
-    expect(logSpy.mock.lastCall).toEqual(['\u001b[36mLogger#info: \u001b[39m', 'testing info']);
+    expect(logSpy.mock.lastCall).toEqual(['Logger#info: ', 'testing info']);
   });
 
   it('should log()', () => {
     this.Logger.log('testing log');
-    expect(logSpy.mock.lastCall).toEqual(['\u001b[36mLogger#log: \u001b[39m', 'testing log']);
+    expect(logSpy.mock.lastCall).toEqual(['Logger#log: ', 'testing log']);
   });
 
   it('should debug()', () => {
     this.Logger.debug('testing debug');
-    expect(logSpy.mock.lastCall).toEqual(['\u001b[36mLogger#debug: \u001b[39m', 'testing debug']);
+    expect(logSpy.mock.lastCall).toEqual(['Logger#debug: ', 'testing debug']);
   });
 
   it('should verbose()', () => {
     this.Logger.verbose('testing verbose');
-    expect(logSpy.mock.lastCall).toEqual(['\u001b[36mLogger#verbose: \u001b[39m', 'testing verbose']);
+    expect(logSpy.mock.lastCall).toEqual(['Logger#verbose: ', 'testing verbose']);
   });
 });


### PR DESCRIPTION
Colors often has a security alert that we need to deal with. This removes is as it's only used when doing local dev and it's not a critical feature to help triage.