### PR TITLE
showcase

### DIFF
--- a/src/fixtures/FixtureCache.js
+++ b/src/fixtures/FixtureCache.js
@@ -4,9 +4,9 @@ module.exports = function (Promise) {
     constructor() {
       this.cache = {};
 
-      this.get.bind(this);
-      this.set.bind(this);
-      this.setAsync.bind(this);
+      // this.get.bind(this);
+      // this.set.bind(this);
+      // this.setAsync.bind(this);
     }
 
     set(key, value) {
@@ -32,6 +32,7 @@ module.exports = function (Promise) {
 
     setAsync(key, value) {
       setTimeout(() => {
+        console.warn("setAsync/setTimeout", this.set);
         this.set(key, value);
       });
     }


### PR DESCRIPTION
## Testing
If you pull this branch and run `npx jest fixturecache --coverage=false` you'll see the `getOrPromise` tests pass with the `should call fetch callback` test verifying the call to `FixtureCache.set` with the correct arguments (not to mention the `console.warn` message).

This indicates the `this.fn.bind(this)` in the `FixtureCache` isn't needed.