### PR TITLE
safer promise handling, uses the passed-in promise if provided, otherwise the global one.

### DIFF
--- a/src/fixtures/FixtureCache.js
+++ b/src/fixtures/FixtureCache.js
@@ -1,39 +1,47 @@
-module.exports = function (Promise) {
+module.exports = function (P) {
+  const PromiseCtor = P || Promise;
+
   class FixtureCache {
-
     constructor() {
-      this.cache = {};
-
-      this.get.bind(this);
-      this.set.bind(this);
-      this.setAsync.bind(this);
+      this.cache = new Map();
+      this.inflight = new Map();
     }
 
     set(key, value) {
-      this.cache[key] = value;
+      this.cache.set(key, value);
     }
 
     get(key) {
-      return this.cache[key];
+      return this.cache.get(key);
     }
 
     getOrPromise(key, fn) {
-      const cacheHit = this.cache[key];
-
-      if (cacheHit) {
-        return Promise.resolve(cacheHit);
+      if (this.cache.has(key)) {
+        return PromiseCtor.resolve(this.cache.get(key));
       }
 
-      return fn().then((result) => {
-        this.setAsync(key, result);
-        return result;
-      });
+      if (this.inflight.has(key)) {
+        return this.inflight.get(key);
+      }
+
+      const p = PromiseCtor.resolve()
+        .then(fn)
+        .then((result) => {
+          this.setAsync(key, result);
+          this.inflight.delete(key);
+          return result;
+        })
+        .catch((err) => {
+          this.inflight.delete(key);
+          throw err;
+        });
+
+      this.inflight.set(key, p);
+      return p;
     }
 
     setAsync(key, value) {
-      setTimeout(() => {
-        this.set(key, value);
-      });
+      setTimeout(() => this.set(key, value), 0);
     }
   }
 


### PR DESCRIPTION
Hey all,

The truthiness bug I also fixed, if (`cacheHit`) failed for cached values like `0`, "", or false. Using Map + `.has()` makes cache hits `reliable.if` (`cacheHit`) failed for cached values like `0`, "", or false. Using Map + `.has()` makes cache hits reliable.

At the end of the day it still calls:

```js
const cache = require('./fixtureCache')(Promise);

cache.set('foo', 123);
cache.get('foo'); // → 123

cache.getOrPromise('bar', () => fetchStuff())
  .then((val) => console.log(val));
```

Cheers,
Michael


